### PR TITLE
changing syntax for gene id in transcript

### DIFF
--- a/strAPI/repeats/models.py
+++ b/strAPI/repeats/models.py
@@ -39,7 +39,7 @@ class Transcript(SQLModel, table=True):
     end: int = Field(nullable=False)
 
     # one to many Gene -> Transcripts
-    gene_id = Field(Integer, foreign_key ="genes.id")
+    gene_id: int = Field(Integer, foreign_key ="genes.id")
 
     gene: "Gene" = Relationship(back_populates="transcripts")
 


### PR DESCRIPTION
My run was breaking without this change, I think due to using more updated libraries for interacting with the SQL.